### PR TITLE
Add update timestamps to v1 files

### DIFF
--- a/rrdb.c
+++ b/rrdb.c
@@ -888,7 +888,7 @@ finishnomodify:
  *
  * Written: 9th March 2013 By: Nick Knight
  ************************************************************************************/
-int updateRRDBFile(char *filename, char* vals) {
+int updateRRDBFile(char *filename, char* vals, unsigned long timestamp) {
   rrdbFile fileData;
   unsigned int i;
   char *result = NULL;
@@ -900,6 +900,7 @@ int updateRRDBFile(char *filename, char* vals) {
 
   struct tm *current_tm;
   time_t current_time;
+  time_t last_time;
 
   int pfd;
 
@@ -919,6 +920,8 @@ int updateRRDBFile(char *filename, char* vals) {
     return -1;
   }
 
+  last_time = fileData.times[fileData.header.windowPosition].time;
+
   /*
     Move round on 1
     */
@@ -928,11 +931,19 @@ int updateRRDBFile(char *filename, char* vals) {
     times
     */
 
+  if (timestamp != 0 && timestamp < last_time) {
+      printf("ERROR: timestamp must be greater than last time\n");
+      return -1;
+  } else if (timestamp != 0 && timestamp >= last_time) {
+      t1.tv_sec = timestamp;
+      t1.tv_usec = 0;
+  } else {
+      gettimeofday(&t1, NULL);
+  }
+
   fileData.times[fileData.header.windowPosition].valid = 1;
-  gettimeofday(&t1, NULL);
   fileData.times[fileData.header.windowPosition].time = t1.tv_sec;
   fileData.times[fileData.header.windowPosition].uSecs = t1.tv_usec;
-
 
   /*
     The vals are a string of seperated vales in the format of num:num:num
@@ -1559,7 +1570,7 @@ int runcreate( char *filename, unsigned int sampleCount, unsigned int setCount, 
  * runs the command
  * Written: 10th March 2013 By: Nick Knight
  */
-int runCommand(char *filename, RRDBCommand ourCommand, unsigned int sampleCount, unsigned int setCount, char *values, char *xformations, char * cperiod) {
+int runCommand(char *filename, RRDBCommand ourCommand, unsigned int sampleCount, unsigned int setCount, char *values, char *xformations, char * cperiod, unsigned long timestamp) {
 
   switch( ourCommand ) {
     case CREATE:
@@ -1572,8 +1583,8 @@ int runCommand(char *filename, RRDBCommand ourCommand, unsigned int sampleCount,
 
     case UPDATE:
       /* we should be given a value for each set we have */
-      return updateRRDBFile( filename, &values[ 0 ] );
-      /* update can fail - but just indicate it needs creating - output will havebeen sent though */
+      return updateRRDBFile( filename, &values[ 0 ], timestamp );
+      /* update can fail - but just indicate it needs creating - output will have been sent though */
       break;
 
     case MODIFY:
@@ -1627,6 +1638,8 @@ int waitForInput(char *dir) {
   char period[MAXCOMMANDLENGTH];
 
   char fulldirname[PATH_MAX + NAME_MAX];
+
+  long timestamp = 0;
 
   command[0] = 0;
   while( TRUE ) {
@@ -1725,7 +1738,7 @@ int waitForInput(char *dir) {
     strcpy( &period[0], result );
   }
 
-  int ret = runCommand(fulldirname, ourCommand, sampleCount, setCount, values, xformations, period);
+  int ret = runCommand(fulldirname, ourCommand, sampleCount, setCount, values, xformations, period, timestamp);
   switch( ret ) {
     case -1:
       break;
@@ -1774,6 +1787,7 @@ int main(int argc, char **argv) {
   char filename[NAME_MAX];
   char period[NAME_MAX];
   int pathlength = 0;
+  long timestamp = 0;
 
   char values[MAXVALUESTRING];
   char xformations[MAXVALUESTRING];
@@ -1789,6 +1803,7 @@ int main(int argc, char **argv) {
       {"xform",       1, 0, 6 },
       {"touchpath",   1, 0, 7 },
       {"period",      1, 0, 8 },
+      {"timestamp",   1, 0, 9 },
       {0,             0, 0, 0 }
   };
 
@@ -1828,8 +1843,8 @@ int main(int argc, char **argv) {
         } else if ( 0 == strcmp("modify", optarg) ) {
           ourCommand = MODIFY;
         }
-
         break;
+
       case 1:
         setCount = atoi(optarg);;
         break;
@@ -1845,7 +1860,6 @@ int main(int argc, char **argv) {
           exit(1);
         }
         strcpy( &dir[0], optarg );
-
         break;
 
       case 4:
@@ -1855,7 +1869,7 @@ int main(int argc, char **argv) {
           exit(1);
         }
         strcpy( &filename[0], optarg );
-  break;
+        break;
 
       case 5:
         /* values */
@@ -1884,9 +1898,15 @@ int main(int argc, char **argv) {
         }
         strcpy( &xformations[0], optarg );
         break;
+
       case 8:
         /* period */
         strcpy( &period[0], optarg );
+        break;
+
+      case 9:
+        /* timestamp */
+        timestamp = atol( optarg );
         break;
 
       default:
@@ -1906,8 +1926,7 @@ int main(int argc, char **argv) {
 
     strcpy(&fulldirname[pathlength], &filename[0]);
 
-    runCommand(fulldirname, ourCommand, sampleCount, setCount, values, xformations, period);
-
+    runCommand(fulldirname, ourCommand, sampleCount, setCount, values, xformations, period, timestamp);
   }
 
   /* mainly to keep users of valgrind happy as to while 3 file descriptors are still open */

--- a/rrdb.h
+++ b/rrdb.h
@@ -141,7 +141,7 @@ int unlockandclose( int pfd );
 int initRRDBFile(char *filename, unsigned int setCount, unsigned int sampleCount , char *xformations);
 int readRRDBFile(int pfd, rrdbFile *fileData); /* RRDB V1 */
 int writeRRDBFile(int pfd, rrdbFile *fileData);
-int updateRRDBFile(char *filename, char* vals);
+int updateRRDBFile(char *filename, char* vals, unsigned long timestamp);
 int modifyRRDBFile(char *filename, char* vals, char* xform);
 int freeRRDBFile(rrdbFile *fileData);
 int printRRDBFile(rrdbFile *fileData);
@@ -151,7 +151,7 @@ int waitForInput(char *dir);
 
 int runfetch( char *filename, char *xformations, char * cperiod );
 int runcreate( char *filename, unsigned int sampleCount, unsigned int setCount, char *xformations );
-int runCommand(char *filename, RRDBCommand ourCommand, unsigned int sampleCount, unsigned int setCount, char *values, char *xformations, char * period);
+int runCommand(char *filename, RRDBCommand ourCommand, unsigned int sampleCount, unsigned int setCount, char *values, char *xformations, char * period, unsigned long timestamp);
 
 int touchRRDBFile(char *filename, char *path, char * period, unsigned int maxsets, unsigned int sampleCount);
 int findTouchSet(int pfd, char *path, unsigned int period, unsigned int maxsets);


### PR DESCRIPTION
- Adds an option to specify the timestamp when updating a v1 RRDB file.
- Note that the specified timestamp must always be greater than the most recent existing timestamp in the file.