### PR TITLE
ci: bump workflow actions to latest majors

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,23 +22,23 @@ jobs:
     steps:
     # Get the repository's code
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
       # https://github.com/docker/setup-qemu-action
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v4
       # https://github.com/docker/setup-buildx-action
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v4
       - name: Login to Docker Hub
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v2
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and export to Docker
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v7
         with:
           context: .
           load: true
@@ -51,7 +51,7 @@ jobs:
 
       - name: Docker meta
         id: ourdockertags
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v6
         with:
           # list of Docker images to use as base name for tags
           images: |
@@ -67,7 +67,7 @@ jobs:
             type=sha
     
       - name: Build and push
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v7
         with:
           context: .
           platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
Bumps the pinned GitHub Action major versions in this repo's workflow(s) to the current latest majors. Upgrade-only and idempotent — only version tokens change, structure untouched.

**Bumps:**
- `actions/checkout` v3 → v6  (`.github/workflows/build.yaml`)
- `docker/setup-qemu-action` v2 → v4  (`.github/workflows/build.yaml`)
- `docker/setup-buildx-action` v2 → v4  (`.github/workflows/build.yaml`)
- `docker/login-action` v2 → v4  (`.github/workflows/build.yaml`)
- `docker/build-push-action` v4 → v7  (`.github/workflows/build.yaml`)
- `docker/metadata-action` v3 → v6  (`.github/workflows/build.yaml`)
- `docker/build-push-action` v4 → v7  (`.github/workflows/build.yaml`)

Part of an org-wide pass bringing every build workflow up to the latest action versions (Turnstile handled separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
